### PR TITLE
Tweak safe-money.cabal

### DIFF
--- a/safe-money.cabal
+++ b/safe-money.cabal
@@ -28,21 +28,21 @@ library
       Data.Money
       Data.Money.Internal
   build-depends:
-      base (>=4.5 && <5.0)
-    , constraints
+      base (>=4.9 && <5.0)
+    , constraints == 0.8.*
 
   if flag(aeson)
-    build-depends: aeson
+    build-depends: aeson == 1.0.*
   if flag(binary)
-    build-depends: binary
+    build-depends: binary == 0.8.*
   if flag(cereal)
-    build-depends: cereal
+    build-depends: cereal == 0.5.*
   if flag(deepseq)
-    build-depends: deepseq
+    build-depends: deepseq == 1.4.*
   if flag(hashable)
-    build-depends: hashable
+    build-depends: hashable == 1.2.*
   if flag(store)
-    build-depends: store
+    build-depends: store == 0.3.*
 
 test-suite tests
   default-language: Haskell2010
@@ -66,19 +66,25 @@ test-suite tests
 -- Provide instances for @aeson@
 flag aeson
   default: True
+  manual: True
 -- Provide instances for @binary@
 flag binary
   default: True
+  manual: True
 -- Provide instances for @cereal@
 flag cereal
   default: True
+  manual: True
 -- Provide instances for @store@
 flag store
   default: True
+  manual: True
 -- Provide instances for @hashable@
 flag hashable
   default: True
+  manual: True
 -- Provide instances for @deepseq@
 flag deepseq
   default: True
+  manual: True
 


### PR DESCRIPTION
This fixes a few minor issues with the `.cabal` file I noticed

 - flags toggling dependencies or features ought to be manual, otherwise the cabal solver can toggle them during the solving process (in an non always obvious way)
 - This package only compiles with GHC 8.0 currently (despite #1 having been merged), so the lower bound `base >=4.9` encodes this
 - The remaining library dependencies ought to have accurate version bounds as well for Hackage to help ensure old versions don't become uninstallable over time

If you have any questions, please let me know!