### PR TITLE
Fix flag logic

### DIFF
--- a/safe-money.cabal
+++ b/safe-money.cabal
@@ -68,7 +68,7 @@ test-suite test
     tasty,
     tasty-hunit,
     tasty-quickcheck
-  if (flag(store) || !impl(ghcjs))
+  if (flag(store) && !impl(ghcjs))
     build-depends: store
 
 flag aeson


### PR DESCRIPTION
Previously, store was always a test dependency when using anything other than GHCJS.

(This was already correct in the library section)