### PR TITLE
fix MDL scale

### DIFF
--- a/safe-money/changelog.md
+++ b/safe-money/changelog.md
@@ -6,6 +6,8 @@
 
 * Add `someXxxToDecimal`. See issue #44.
 
+* Fix `MDL` scale. See issue #50.
+
 
 # Version 0.8
 

--- a/safe-money/src/Money.hs
+++ b/safe-money/src/Money.hs
@@ -484,7 +484,7 @@ type instance I.UnitScale "MAD" "dirham" = '(1, 1)
 type instance I.UnitScale "MAD" "centime" = '(100, 1)
 -- | Moldovan leu
 type instance I.CurrencyScale "MDL" = I.UnitScale "MDL" "ban"
-type instance I.UnitScale "MDL" "leu" = '(100, 1)
+type instance I.UnitScale "MDL" "leu" = '(1, 1)
 type instance I.UnitScale "MDL" "ban" = '(100, 1)
 -- | Malagasy ariary
 type instance I.CurrencyScale "MGA" = I.UnitScale "MGA" "iraimbilanja"


### PR DESCRIPTION
```
> I.denseFromDiscrete (1 :: I.Discrete "MDL" "ban")
Dense "MDL" 1%100
> I.denseFromDiscrete (1 :: I.Discrete "MDL" "leu")
Dense "MDL" 1%100
```

But should be

```
> I.denseFromDiscrete (1 :: I.Discrete "MDL" "ban")
Dense "MDL" 1%100
> I.denseFromDiscrete (1 :: I.Discrete "MDL" "leu")
Dense "MDL" 1%1
```